### PR TITLE
Adjust main fade gradients to use length-based stops

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -273,10 +273,11 @@ main::before {
   height: calc(var(--sentence-fade-top-edge) + var(--sentence-fade-band));
   background: linear-gradient(
     to bottom,
-    var(--background) 0%,
-    rgba(5, 5, 5, 0.9) 38%,
-    rgba(5, 5, 5, 0.62) 66%,
-    rgba(5, 5, 5, 0) 100%
+    var(--background) 0,
+    var(--background) var(--sentence-fade-top-edge),
+    rgba(5, 5, 5, 0.9) calc(var(--sentence-fade-top-edge) + var(--sentence-fade-band) * 0.25),
+    rgba(5, 5, 5, 0.62) calc(var(--sentence-fade-top-edge) + var(--sentence-fade-band) * 0.66),
+    rgba(5, 5, 5, 0) calc(var(--sentence-fade-top-edge) + var(--sentence-fade-band))
   );
 }
 
@@ -285,10 +286,11 @@ main::after {
   height: calc(var(--sentence-fade-bottom-edge) + var(--sentence-fade-band));
   background: linear-gradient(
     to top,
-    var(--background) 0%,
-    rgba(5, 5, 5, 0.9) 38%,
-    rgba(5, 5, 5, 0.62) 66%,
-    rgba(5, 5, 5, 0) 100%
+    var(--background) 0,
+    var(--background) var(--sentence-fade-bottom-edge),
+    rgba(5, 5, 5, 0.9) calc(var(--sentence-fade-bottom-edge) + var(--sentence-fade-band) * 0.25),
+    rgba(5, 5, 5, 0.62) calc(var(--sentence-fade-bottom-edge) + var(--sentence-fade-band) * 0.66),
+    rgba(5, 5, 5, 0) calc(var(--sentence-fade-bottom-edge) + var(--sentence-fade-band))
   );
 }
 


### PR DESCRIPTION
## Summary
- express the main fade overlays using calc-based stop positions tied to the fade edge and band variables
- keep the opaque span intact while blending across the configured fade band for both top and bottom overlays

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6693360c88331bc9a334891582d38