### PR TITLE
Fix sentences fade overlay to remain stationary

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -460,32 +460,6 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
   margin: 0 auto;
   padding: clamp(48px, 22vh, 200px) clamp(24px, 8vw, 140px) clamp(200px, 52vh, 420px);
   perspective: 1400px;
-  --fade-top-edge: var(--sentence-fade-top-edge);
-  --fade-bottom-edge: var(--sentence-fade-bottom-edge);
-  --fade-band: var(--sentence-fade-band);
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    transparent 0,
-    transparent var(--fade-top-edge),
-    black calc(var(--fade-top-edge) + var(--fade-band)),
-    black calc(100% - var(--fade-bottom-edge) - var(--fade-band)),
-    transparent calc(100% - var(--fade-bottom-edge)),
-    transparent 100%
-  );
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
-  mask-image: linear-gradient(
-    to bottom,
-    transparent 0,
-    transparent var(--fade-top-edge),
-    black calc(var(--fade-top-edge) + var(--fade-band)),
-    black calc(100% - var(--fade-bottom-edge) - var(--fade-band)),
-    transparent calc(100% - var(--fade-bottom-edge)),
-    transparent 100%
-  );
-  mask-size: 100% 100%;
-  mask-repeat: no-repeat;
-  mask-mode: alpha;
 }
 
 .sentence {


### PR DESCRIPTION
## Summary
- remove the section-scoped mask so the sentences list is no longer clipped relative to its own scroll position
- rely on fixed main pseudo-elements with the existing gradient overlay to keep the fade anchored to the viewport

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68d66a72399083319ebd5d027906bac3