### PR TITLE
Adjust mobile padding offsets for sentences section

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -579,7 +579,10 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
   }
 
   #sentences {
-    padding: clamp(48px, 16vh, 120px) clamp(20px, 9vw, 52px) clamp(200px, 56vh, 360px);
+    padding-top: calc(var(--sentences-padding-top) + clamp(48px, 16vh, 120px));
+    padding-right: clamp(20px, 9vw, 52px);
+    padding-bottom: calc(var(--sentences-padding-bottom) + clamp(200px, 56vh, 360px));
+    padding-left: clamp(20px, 9vw, 52px);
   }
 
   .sentence {


### PR DESCRIPTION
## Summary
- include the same fade-zone padding offsets on the mobile `#sentences` styles
- layer the mobile-specific clamp spacing on top of the base offsets for consistent scroll behavior

## Testing
- Manual verification in a 390×844 viewport


------
https://chatgpt.com/codex/tasks/task_e_68d6e89b8cc883319b866e0cdf27141c