### PR TITLE
Adjust mobile sentences padding offsets

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -579,9 +579,19 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
   }
 
   #sentences {
-    padding-top: calc(var(--sentences-padding-top) + clamp(48px, 16vh, 120px));
+    padding-top:
+      calc(
+        var(--sentences-padding-top)
+        + clamp(48px, 18vh, 180px)
+        + clamp(24px, 12vh, 96px)
+      );
     padding-right: clamp(20px, 9vw, 52px);
-    padding-bottom: calc(var(--sentences-padding-bottom) + clamp(200px, 56vh, 360px));
+    padding-bottom:
+      calc(
+        var(--sentences-padding-bottom)
+        + clamp(160px, 40vh, 360px)
+        + clamp(120px, 32vh, 280px)
+      );
     padding-left: clamp(20px, 9vw, 52px);
   }
 


### PR DESCRIPTION
## Summary
- adjust the mobile `#sentences` padding so the base offsets are preserved and extra spacing is layered via clamps
- ensure the active sentence clears the fade band while header and footer remain hidden on small viewports

## Testing
- Manual verification at 390×844 viewport

------
https://chatgpt.com/codex/tasks/task_e_68d6e9dd59348331b66fba9c04f0b807