### PR TITLE
Retune mobile sentences padding clamps

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -579,9 +579,17 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
   }
 
   #sentences {
-    padding-top: calc(var(--sentences-padding-top) + clamp(48px, 16vh, 120px));
+    padding-top:
+      calc(
+        var(--sentences-padding-top)
+        + clamp(32px, 8vh, 104px)
+      );
     padding-right: clamp(20px, 9vw, 52px);
-    padding-bottom: calc(var(--sentences-padding-bottom) + clamp(200px, 56vh, 360px));
+    padding-bottom:
+      calc(
+        var(--sentences-padding-bottom)
+        + clamp(200px, 50vh, 420px)
+      );
     padding-left: clamp(20px, 9vw, 52px);
   }
 


### PR DESCRIPTION
## Summary
- reduce the mobile #sentences top padding clamp so the active sentence clears the fade band
- widen the mobile bottom padding clamp to keep the footer masked until after the fade zone

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e9dd59348331b66fba9c04f0b807