### PR TITLE
Nest header brand text inside shared container

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,16 +22,14 @@
 
   <header class="site-header">
     <div class="site-header__inner">
-      <div class="site-lockup">
-        <button
-          class="site-brand"
-          type="button"
-          data-scroll-to-sentences
-          aria-label="CLASSNOE MESTO — scroll to first message"
-        >
-          CLASSNOE MESTO
-        </button>
-      </div>
+      <button
+        class="site-brand"
+        type="button"
+        data-scroll-to-sentences
+        aria-label="CLASSNOE MESTO — scroll to first message"
+      >
+        CLASSNOE MESTO
+      </button>
       <button
         class="site-menu-toggle"
         type="button"

--- a/styles.css
+++ b/styles.css
@@ -290,22 +290,6 @@ main {
   text-align: center;
 }
 
-.site-lockup {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: clamp(8px, 1.6vw, 16px);
-  transition: opacity 360ms ease-in-out, transform 360ms ease-in-out;
-}
-
-body.has-menu-open .site-lockup,
-body.is-menu-closing .site-lockup {
-  opacity: 0;
-  transform: translateY(-8px);
-  pointer-events: none;
-}
-
 .site-brand {
   display: inline-flex;
   align-items: center;
@@ -326,7 +310,14 @@ body.is-menu-closing .site-lockup {
   text-shadow: 0 0 32px rgba(255, 255, 255, 0.28);
   text-align: center;
   white-space: nowrap;
-  transition: color 200ms ease;
+  transition: color 200ms ease, opacity 360ms ease-in-out, transform 360ms ease-in-out;
+}
+
+body.has-menu-open .site-brand,
+body.is-menu-closing .site-brand {
+  opacity: 0;
+  transform: translateY(-8px);
+  pointer-events: none;
 }
 
 .site-brand:hover {


### PR DESCRIPTION
## Summary
- move the CLASSNOE MESTO brand button directly into the shared header container
- port the previous lockup transition behavior to the brand element so menu animations remain consistent

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d7881f8a988331a519d9d1f26961ef