### PR TITLE
Fix safe area background handling on iOS

### DIFF
--- a/safe-area.js
+++ b/safe-area.js
@@ -24,6 +24,22 @@
   }
 
   let baseInsets = readBaseInsets();
+  let lastReported = '';
+
+  function report(source) {
+    const styles = getComputedStyle(root);
+    const current = {
+      top: styles.getPropertyValue('--safe-top').trim(),
+      right: styles.getPropertyValue('--safe-right').trim(),
+      bottom: styles.getPropertyValue('--safe-bottom').trim(),
+      left: styles.getPropertyValue('--safe-left').trim(),
+    };
+    const snapshot = JSON.stringify(current);
+    if (snapshot !== lastReported) {
+      console.info(`[safe-area] ${source}`, current);
+      lastReported = snapshot;
+    }
+  }
 
   function update() {
     const top = vv ? Math.max(baseInsets.top, Math.max(0, vv.offsetTop)) : baseInsets.top;
@@ -45,6 +61,7 @@
     root.style.setProperty('--safe-bottom', bottom + 'px');
     root.style.setProperty('--safe-left', left + 'px');
     root.style.setProperty('--safe-right', right + 'px');
+    report('update');
   }
 
   update();

--- a/styles.css
+++ b/styles.css
@@ -42,19 +42,20 @@
 html,
 body {
   margin: 0;
-  height: 100%;
   background: #000;
   color: #fff;
   font-family: Arial, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
 }
 
 html {
+  min-height: 100%;
   background: var(--background);
 }
 
 body {
   position: relative;
   min-height: 100vh;
+  min-height: 100dvh;
   background: var(--background);
   color: var(--text-strong);
   font-family: var(--font-serif);
@@ -70,8 +71,8 @@ body.is-menu-closing {
 }
 
 .content {
-  min-height: 100dvh;
   min-height: 100vh;
+  min-height: 100dvh;
   box-sizing: border-box;
   padding:
     calc(16px + var(--safe-top))


### PR DESCRIPTION
## Summary
- allow the page background to extend into iOS unsafe areas by relying on min-height and 100dvh
- log the computed safe-area CSS variables for easier debugging when values change

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7e500139c83319476d98eec29dde4