### PR TITLE
Fix safe area background coverage on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,8 @@
       "We work from Saint Petersburg, collaborating around the world on projects that make life a little more thoughtful."
     ];
     window.SITE_CONFIG = { SENTENCES };
+    console.log(getComputedStyle(document.documentElement).getPropertyValue('--safe-top'));
+    console.log(getComputedStyle(document.documentElement).getPropertyValue('--safe-bottom'));
   </script>
   <script defer src="./script.js"></script>
 </body>

--- a/safe-area-test.html
+++ b/safe-area-test.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <title>Safe Area Background Test</title>
+    <style>
+      :root {
+        --safe-top: env(safe-area-inset-top, 0px);
+        --safe-bottom: env(safe-area-inset-bottom, 0px);
+      }
+
+      html,
+      body {
+        margin: 0;
+        min-height: 100vh;
+        min-height: 100dvh;
+        background: red;
+      }
+
+      main {
+        display: grid;
+        place-items: center;
+        min-height: 100vh;
+        min-height: 100dvh;
+        color: #fff;
+        font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div>
+        <h1>Safe Area Background Test</h1>
+        <p>The red background should bleed into the unsafe areas.</p>
+      </div>
+    </main>
+    <script>
+      console.log(getComputedStyle(document.documentElement).getPropertyValue('--safe-top'));
+      console.log(getComputedStyle(document.documentElement).getPropertyValue('--safe-bottom'));
+    </script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -42,13 +42,14 @@
 html,
 body {
   margin: 0;
+  min-height: 100vh;
+  min-height: 100dvh;
   background: #000;
   color: #fff;
   font-family: Arial, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
 }
 
 html {
-  min-height: 100%;
   background: var(--background);
 }
 


### PR DESCRIPTION
## Summary
- ensure the root html element stretches to the physical viewport so the body background can cover unsafe areas
- log the computed safe area variables to the console to validate Safari picks them up
- add a minimal safe-area test page with a solid background for manual verification

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e6c1286c83318f9da97467ff806f