### PR TITLE
Add safe-area debug toggles and zebra test mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,9 @@
   <meta property="og:title" content="CLASSNOE MESTO — Inspired Tribute" />
   <meta property="og:description" content="An homage to CLASSNOE MESTO's scrolling narrative experience." />
   <meta property="og:type" content="website" />
-  <meta name="theme-color" content="#0b0b0b" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="theme-color" content="#000000" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
@@ -118,6 +120,14 @@
 
   <script src="./safe-area.js"></script>
   <script>
+    (function () {
+      const qs = new URLSearchParams(location.search);
+      if (qs.get('safetest') === '1') {
+        document.documentElement.classList.add('safe-test');
+      }
+    })();
+  </script>
+  <script>
     const SENTENCES = [
       "CLASSNOE MESTO is a creative collective of designers, architects, musicians, filmmakers, writers, and engineers.",
       "We are fascinated by the traditions of craft and defined by the pursuit of excellence.",
@@ -136,6 +146,12 @@
   ></pre>
   <script>
     (function () {
+      const qs = new URLSearchParams(location.search);
+      if (!qs.has('debug') || qs.get('debug') !== 'safe') {
+        const dbg = document.getElementById('safe-debug');
+        if (dbg) dbg.remove();
+        return;
+      }
       function dump() {
         const cs = getComputedStyle(document.documentElement);
         const t = cs.getPropertyValue('--safe-top').trim();

--- a/safe-area.js
+++ b/safe-area.js
@@ -9,10 +9,9 @@
     const right = vv ? Math.max(0, window.innerWidth - (vv.width + vv.offsetLeft)) : null;
 
     function setVar(name, val) {
-      if (val === null) return;
-      const current = getComputedStyle(root).getPropertyValue(name).trim();
-      const currentNumber = current ? parseFloat(current) : NaN;
-      if (!current || (Number.isFinite(currentNumber) && currentNumber === 0 && val > 0)) {
+      if (val == null) return;
+      const current = parseFloat(getComputedStyle(root).getPropertyValue(name)) || 0;
+      if (Math.abs(current - val) > 0.5) {
         root.style.setProperty(name, val + 'px');
       }
     }

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,7 @@
   --safe-right: env(safe-area-inset-right, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
   --safe-left: env(safe-area-inset-left, 0px);
+  --content-bg: transparent;
 }
 
 @supports (height: 100dvh) {
@@ -48,6 +49,7 @@ body {
   min-height: 100dvh;
   background: #000;
   color: #fff;
+  /* iOS: раскрытые панели браузера остаются системным хромом — unsafe-зоны видны лишь при схлопнутых панелях или в PWA */
 }
 
 body {
@@ -74,7 +76,7 @@ body.is-menu-closing {
     calc(16px + var(--safe-right))
     calc(16px + var(--safe-bottom))
     calc(16px + var(--safe-left));
-  background: transparent !important;
+  background: var(--content-bg);
 }
 
 .visually-hidden {
@@ -126,6 +128,17 @@ body::after {
     100% clamp(160px, calc(var(--viewport-unit) * 34), 360px),
     100% clamp(160px, calc(var(--viewport-unit) * 34), 360px),
     100% clamp(200px, calc(var(--viewport-unit) * 42), 420px);
+}
+
+html.safe-test,
+html.safe-test body {
+  background:
+    repeating-linear-gradient(to bottom, #000 0, #000 8px, #111 8px, #111 16px);
+}
+
+html.safe-test body::before,
+html.safe-test body::after {
+  display: none;
 }
 
 .backdrop {


### PR DESCRIPTION
## Summary
- gate the safe-area debug overlay behind the ?debug=safe flag and add a ?safetest=1 zebra overlay helper
- expose a --content-bg variable for theming and document iOS safe-area behaviour
- update the safe-area variable setter to react to shrinking insets and add mobile web app meta tags

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68d7eb41c488833195ad249609b925ef