### PR TITLE
Clamp UI to safe area insets

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,99 +23,105 @@
   <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
-  <div class="content">
-    <div class="backdrop" aria-hidden="true"></div>
+  <div class="safe-frame">
+    <div class="content">
+      <div class="backdrop" aria-hidden="true"></div>
 
-    <header class="site-header">
-      <div class="site-header__inner">
-        <div class="site-lockup">
+      <header class="site-header">
+        <div class="site-header__inner">
+          <div class="site-lockup">
+            <button
+              class="site-brand"
+              type="button"
+              data-scroll-to-sentences
+              aria-label="CLASSNOE MESTO — scroll to first message"
+            >
+              CLASSNOE MESTO
+            </button>
+          </div>
           <button
-            class="site-brand"
+            class="site-menu-toggle"
             type="button"
-            data-scroll-to-sentences
-            aria-label="CLASSNOE MESTO — scroll to first message"
+            data-menu-toggle
+            aria-expanded="false"
+            aria-controls="site-menu"
+            aria-label="Open menu"
           >
-            CLASSNOE MESTO
+            <span class="site-menu-toggle__icon" aria-hidden="true">
+              <span></span>
+              <span></span>
+              <span></span>
+            </span>
           </button>
         </div>
-        <button
-          class="site-menu-toggle"
-          type="button"
-          data-menu-toggle
-          aria-expanded="false"
-          aria-controls="site-menu"
-          aria-label="Open menu"
-        >
-          <span class="site-menu-toggle__icon" aria-hidden="true">
-            <span></span>
-            <span></span>
-            <span></span>
-          </span>
-        </button>
-      </div>
-    </header>
+      </header>
 
-    <div
-      id="site-menu"
-      class="site-menu"
-      role="dialog"
-      aria-modal="true"
-      aria-label="Site navigation"
-      aria-hidden="true"
-      hidden
-    >
-      <div class="site-menu__backdrop" data-menu-close></div>
-      <div class="site-menu__container" role="document" tabindex="-1" data-menu-focus>
-        <nav class="site-menu__nav" aria-label="Primary">
-          <ul class="site-menu__list" role="list">
-            <li class="site-menu__item">
-              <a href="#content" class="site-menu__link" data-menu-link>Branding</a>
-            </li>
-            <li class="site-menu__item">
-              <a href="#content" class="site-menu__link" data-menu-link>Packaging</a>
-            </li>
-            <li class="site-menu__item">
-              <a href="#content" class="site-menu__link" data-menu-link>Social Media</a>
-            </li>
-            <li class="site-menu__item">
-              <a href="#content" class="site-menu__link" data-menu-link>Templates</a>
-            </li>
-            <li class="site-menu__item">
-              <a href="#content" class="site-menu__link" data-menu-link>Web Design</a>
-            </li>
-            <li class="site-menu__item">
-              <a href="#content" class="site-menu__link" data-menu-link>Monthly Design</a>
-            </li>
-          </ul>
-        </nav>
+      <div
+        id="site-menu"
+        class="site-menu"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Site navigation"
+        aria-hidden="true"
+        hidden
+      >
+        <div class="site-menu__backdrop" data-menu-close></div>
+        <div class="site-menu__container" role="document" tabindex="-1" data-menu-focus>
+          <nav class="site-menu__nav" aria-label="Primary">
+            <ul class="site-menu__list" role="list">
+              <li class="site-menu__item">
+                <a href="#content" class="site-menu__link" data-menu-link>Branding</a>
+              </li>
+              <li class="site-menu__item">
+                <a href="#content" class="site-menu__link" data-menu-link>Packaging</a>
+              </li>
+              <li class="site-menu__item">
+                <a href="#content" class="site-menu__link" data-menu-link>Social Media</a>
+              </li>
+              <li class="site-menu__item">
+                <a href="#content" class="site-menu__link" data-menu-link>Templates</a>
+              </li>
+              <li class="site-menu__item">
+                <a href="#content" class="site-menu__link" data-menu-link>Web Design</a>
+              </li>
+              <li class="site-menu__item">
+                <a href="#content" class="site-menu__link" data-menu-link>Monthly Design</a>
+              </li>
+            </ul>
+          </nav>
+        </div>
       </div>
+
+      <main id="content" aria-labelledby="content-title">
+        <h1 id="content-title" class="visually-hidden">CLASSNOE MESTO inspired narrative</h1>
+        <section id="sentences" role="list" aria-live="polite"></section>
+      </main>
+
+      <footer class="site-footer" aria-label="Footer">
+        <div class="site-footer__inner">
+          <div class="site-footer__column">
+            <h2>Inquiries</h2>
+            <a href="mailto:hello@classnoemesto.com">hello@classnoemesto.com</a>
+          </div>
+          <div class="site-footer__column">
+            <h2>Press</h2>
+            <a href="mailto:press@classnoemesto.com">press@classnoemesto.com</a>
+          </div>
+          <div class="site-footer__column">
+            <h2>Follow</h2>
+            <a
+              href="https://www.instagram.com/classnoemesto/"
+              target="_blank"
+              rel="noreferrer noopener"
+            >Instagram</a>
+          </div>
+        </div>
+      </footer>
     </div>
-
-    <main id="content" aria-labelledby="content-title">
-      <h1 id="content-title" class="visually-hidden">CLASSNOE MESTO inspired narrative</h1>
-      <section id="sentences" role="list" aria-live="polite"></section>
-    </main>
-
-    <footer class="site-footer" aria-label="Footer">
-      <div class="site-footer__inner">
-        <div class="site-footer__column">
-          <h2>Inquiries</h2>
-          <a href="mailto:hello@classnoemesto.com">hello@classnoemesto.com</a>
-        </div>
-        <div class="site-footer__column">
-          <h2>Press</h2>
-          <a href="mailto:press@classnoemesto.com">press@classnoemesto.com</a>
-        </div>
-        <div class="site-footer__column">
-          <h2>Follow</h2>
-          <a
-            href="https://www.instagram.com/classnoemesto/"
-            target="_blank"
-            rel="noreferrer noopener"
-          >Instagram</a>
-        </div>
-      </div>
-    </footer>
+    <pre
+      id="safe-debug"
+      style="position:fixed;left:calc(var(--safe-left) + 8px);bottom:calc(var(--safe-bottom) + 8px);padding:6px 8px;background:rgba(0,0,0,.6);color:#0f0;font:12px/1.4 ui-monospace,Menlo,Consolas,monospace;z-index:99999;border-radius:6px;"
+    ></pre>
   </div>
 
   <script src="./safe-area.js"></script>
@@ -140,10 +146,6 @@
     console.log(getComputedStyle(document.documentElement).getPropertyValue('--safe-bottom'));
   </script>
   <script defer src="./script.js"></script>
-  <pre
-    id="safe-debug"
-    style="position:fixed;left:8px;bottom:8px;padding:6px 8px;background:rgba(0,0,0,.6);color:#0f0;font:12px/1.4 ui-monospace,Menlo,Consolas,monospace;z-index:99999;border-radius:6px;"
-  ></pre>
   <script>
     (function () {
       const qs = new URLSearchParams(location.search);

--- a/styles.css
+++ b/styles.css
@@ -61,9 +61,30 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+.safe-frame {
+  position: fixed;
+  top: var(--safe-top);
+  right: var(--safe-right);
+  bottom: var(--safe-bottom);
+  left: var(--safe-left);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  contain: layout paint size;
+  z-index: 0;
+}
+
 body.has-menu-open,
 body.is-menu-closing {
   overflow: hidden;
+}
+
+.safe-frame .content {
+  position: relative;
+  flex: 1 1 auto;
+  height: 100%;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .content {
@@ -71,11 +92,8 @@ body.is-menu-closing {
   min-height: 100vh;
   min-height: 100svh;
   min-height: 100dvh;
-  padding:
-    calc(16px + var(--safe-top))
-    calc(16px + var(--safe-right))
-    calc(16px + var(--safe-bottom))
-    calc(16px + var(--safe-left));
+  min-height: calc((var(--viewport-unit) * 100) - (var(--safe-top) + var(--safe-bottom)));
+  padding: 16px;
   background: var(--content-bg);
 }
 
@@ -195,14 +213,17 @@ body.is-menu-closing .site-menu-toggle {
 
 .site-menu {
   position: fixed;
-  inset: calc(var(--overscroll-bleed) * -1) 0;
+  top: calc(var(--safe-top) - var(--overscroll-bleed));
+  right: var(--safe-right);
+  bottom: calc(var(--safe-bottom) - var(--overscroll-bleed));
+  left: var(--safe-left);
   display: grid;
   place-items: center;
   padding:
-    calc(var(--safe-top) + clamp(32px, 6vw, 96px))
-    calc(var(--safe-right) + clamp(32px, 6vw, 96px))
-    calc(var(--safe-bottom) + clamp(32px, 6vw, 96px))
-    calc(var(--safe-left) + clamp(32px, 6vw, 96px));
+    calc(var(--overscroll-bleed) + clamp(32px, 6vw, 96px))
+    clamp(32px, 6vw, 96px)
+    calc(var(--overscroll-bleed) + clamp(32px, 6vw, 96px))
+    clamp(32px, 6vw, 96px);
   background: rgba(5, 5, 5, 0.82);
   backdrop-filter: blur(28px);
   z-index: 10;
@@ -463,6 +484,8 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
   width: min(920px, 100%);
   margin: 0 auto;
   padding: clamp(48px, 22vh, 200px) clamp(24px, 8vw, 140px) clamp(200px, 52vh, 420px);
+  max-height: calc((var(--viewport-unit) * 100) - (var(--safe-top) + var(--safe-bottom)));
+  overflow: hidden;
   perspective: 1400px;
 }
 
@@ -515,7 +538,7 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
   padding:
     clamp(80px, 18vh, 140px)
     clamp(24px, 8vw, 160px)
-    calc(var(--safe-bottom) + clamp(60px, 18vh, 160px))
+    clamp(60px, 18vh, 160px)
     clamp(24px, 8vw, 160px);
   color: var(--text-muted);
 }
@@ -598,10 +621,10 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
 
   .site-menu {
     padding:
-      calc(var(--safe-top) + clamp(20px, 8vw, 64px))
-      calc(var(--safe-right) + clamp(20px, 8vw, 64px))
-      calc(var(--safe-bottom) + clamp(20px, 8vw, 64px))
-      calc(var(--safe-left) + clamp(20px, 8vw, 64px));
+      calc(var(--overscroll-bleed) + clamp(20px, 8vw, 64px))
+      clamp(20px, 8vw, 64px)
+      calc(var(--overscroll-bleed) + clamp(20px, 8vw, 64px))
+      clamp(20px, 8vw, 64px);
   }
 
   .site-menu__container {


### PR DESCRIPTION
## Summary
- wrap the rendered experience in a fixed `.safe-frame` so unsafe-area overflow is clipped and scrolling stays inside the frame
- retune content padding, the fixed menu overlay, and the sentences stack to respect safe-area inset variables instead of duplicating offsets
- move the safe-area debug badge inside the clipped frame and update footer spacing so elements sit correctly above the home indicator

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7ecaae96c833199344cddedd19953